### PR TITLE
Multiple delete support (#10)

### DIFF
--- a/docs/usage/commands.rst
+++ b/docs/usage/commands.rst
@@ -42,8 +42,7 @@ Manage projects
    $ selvpc project show <project_id> [--show-base64] [--show-short-base64]
    $ selvpc project update <project_id> [--name VALUE] [--logo VALUE] [--color VALUE] [--reset-logo] [--reset-color]
    [--reset-theme] [--reset-cname] [--show-base64] [--show-short-base64]
-   $ selvpc project delete <project_id> --yes-i-really-want-to-delete
-   $ selvpc project delete <project_id_1> <project_id_2> <project_id_3> --yes-i-really-want-to-delete
+   $ selvpc project delete <project_id_1> ... <project_id_n> --yes-i-really-want-to-delete
 
 .. note::
    The key **--yes-i-really-want-to-delete** is required always.
@@ -78,8 +77,7 @@ Manage users
    $ selvpc user roles <user_id>
    $ selvpc user create --name VALUE --password VALUE [--enabled VALUE]
    $ selvpc user update <user_id> --name VALUE --password VALUE --enabled VALUE
-   $ selvpc user delete <user_id> --yes-i-really-want-to-delete
-   $ selvpc user delete <user_id_1> <user_id_2> <user_id_3> --yes-i-really-want-to-delete
+   $ selvpc user delete <user_id_1> ... <user_id_n> --yes-i-really-want-to-delete
 
 .. note::
    If you want to update some property, such as a password, you do not need to specify all fields like name or enabled. Suffice it **user_id** and **password**
@@ -102,8 +100,7 @@ Manage licenses
    $ selvpc license list [--detailed]
    $ selvpc license show <license_id>
    $ selvpc license add <project_id> --region VALUE --type VALUE [--quantity VALUE]
-   $ selvpc license delete <license_id> --yes-i-really-want-to-delete
-   $ selvpc license delete <license_id_1> <license_id_2> <license_id_3> --yes-i-really-want-to-delete
+   $ selvpc license delete <license_id_1> ... <license_id_n> --yes-i-really-want-to-delete
 
 .. note::
    The key **--detailed** show addictional columns like a servers.
@@ -118,8 +115,7 @@ Manage floating ips
    $ selvpc floating list [--detailed]
    $ selvpc floating show <floatingip_id>
    $ selvpc floating add <project_id> --region VALUE [--quantity VALUE]
-   $ selvpc floating delete <floatingip_id> --yes-i-really-want-to-delete
-   $ selvpc floating delete <floatingip_id_1> <floatingip_id_2> <floatingip_id_3> --yes-i-really-want-to-delete
+   $ selvpc floating delete <floatingip_id_1> ... <floatingip_id_n> --yes-i-really-want-to-delete
 
 .. note::
    The key **--detailed** show additional columns like a servers.
@@ -134,8 +130,7 @@ Manage subnets
    $ selvpc subnet list [--detailed]
    $ selvpc subnet show <subnet_id>
    $ selvpc subnet add <project_id> --region VALUE [--type VALUE] [--prefix VALUE] [--quantity VALUE]
-   $ selvpc subnet delete <subnet_id> --yes-i-really-want-to-delete
-   $ selvpc subnet delete <subnet_id_1> <subnet_id_2> <subnet_id_3> --yes-i-really-want-to-delete
+   $ selvpc subnet delete <subnet_id_1> ... <subnet_id_n> --yes-i-really-want-to-delete
 
 .. note::
    The key **--detailed** show addictional columns like a network_id and servers.
@@ -150,8 +145,7 @@ Manage VRRP subnets
    $ selvpc vrrp add --region ru-1 --region ru-2 [--type VALUE] [--prefix VALUE] [--quantity VALUE]
    $ selvpc vrrp list [--project XXX] [--detailed]
    $ selvpc vrrp show <vrrp_id>
-   $ selvpc vrrp delete <vrrp_id> --yes-i-really-want-to-delete
-   $ selvpc vrrp delete <vrrp_id_1> <vrrp_id_2> <vrrp_id_3> --yes-i-really-want-to-delete
+   $ selvpc vrrp delete <vrrp_id_1> ... <vrrp_id_n> --yes-i-really-want-to-delete
 
 .. note::
    Key **detailed** appends additional column: *servers*.

--- a/docs/usage/commands.rst
+++ b/docs/usage/commands.rst
@@ -43,6 +43,7 @@ Manage projects
    $ selvpc project update <project_id> [--name VALUE] [--logo VALUE] [--color VALUE] [--reset-logo] [--reset-color]
    [--reset-theme] [--reset-cname] [--show-base64] [--show-short-base64]
    $ selvpc project delete <project_id> --yes-i-really-want-to-delete
+   $ selvpc project delete <project_id_1> <project_id_2> <project_id_3> --yes-i-really-want-to-delete
 
 .. note::
    The key **--yes-i-really-want-to-delete** is required always.
@@ -78,6 +79,7 @@ Manage users
    $ selvpc user create --name VALUE --password VALUE [--enabled VALUE]
    $ selvpc user update <user_id> --name VALUE --password VALUE --enabled VALUE
    $ selvpc user delete <user_id> --yes-i-really-want-to-delete
+   $ selvpc user delete <user_id_1> <user_id_2> <user_id_3> --yes-i-really-want-to-delete
 
 .. note::
    If you want to update some property, such as a password, you do not need to specify all fields like name or enabled. Suffice it **user_id** and **password**
@@ -101,6 +103,7 @@ Manage licenses
    $ selvpc license show <license_id>
    $ selvpc license add <project_id> --region VALUE --type VALUE [--quantity VALUE]
    $ selvpc license delete <license_id> --yes-i-really-want-to-delete
+   $ selvpc license delete <license_id_1> <license_id_2> <license_id_3> --yes-i-really-want-to-delete
 
 .. note::
    The key **--detailed** show addictional columns like a servers.
@@ -116,9 +119,10 @@ Manage floating ips
    $ selvpc floating show <floatingip_id>
    $ selvpc floating add <project_id> --region VALUE [--quantity VALUE]
    $ selvpc floating delete <floatingip_id> --yes-i-really-want-to-delete
+   $ selvpc floating delete <floatingip_id_1> <floatingip_id_2> <floatingip_id_3> --yes-i-really-want-to-delete
 
 .. note::
-   The key **--detailed** show addictional columns like a servers.
+   The key **--detailed** show additional columns like a servers.
 
 .. note::
    Key **quantity** by default is **1**
@@ -131,6 +135,7 @@ Manage subnets
    $ selvpc subnet show <subnet_id>
    $ selvpc subnet add <project_id> --region VALUE [--type VALUE] [--prefix VALUE] [--quantity VALUE]
    $ selvpc subnet delete <subnet_id> --yes-i-really-want-to-delete
+   $ selvpc subnet delete <subnet_id_1> <subnet_id_2> <subnet_id_3> --yes-i-really-want-to-delete
 
 .. note::
    The key **--detailed** show addictional columns like a network_id and servers.
@@ -142,10 +147,11 @@ Manage VRRP subnets
 ~~~~~~~~~~~~~~~~~~~
 .. code-block:: console
 
-   selvpc vrrp add --region ru-1 --region ru-2 [--type VALUE] [--prefix VALUE] [--quantity VALUE]
-   selvpc vrrp list [--project XXX] [--detailed]
-   selvpc vrrp show 9
-   selvpc vrrp delete 9 --yes-i-really-want-to-delete
+   $ selvpc vrrp add --region ru-1 --region ru-2 [--type VALUE] [--prefix VALUE] [--quantity VALUE]
+   $ selvpc vrrp list [--project XXX] [--detailed]
+   $ selvpc vrrp show <vrrp_id>
+   $ selvpc vrrp delete <vrrp_id> --yes-i-really-want-to-delete
+   $ selvpc vrrp delete <vrrp_id_1> <vrrp_id_2> <vrrp_id_3> --yes-i-really-want-to-delete
 
 .. note::
    Key **detailed** appends additional column: *servers*.

--- a/docs/usage/library.rst
+++ b/docs/usage/library.rst
@@ -90,6 +90,22 @@ Add Windows license
     >>> licenses = selvpc.licenses.add(project.id, licenses=licenses)
 
 
+Delete objects
+~~~~~~~~~~~~~~
+It's possible to delete few object at once. Key **raise_if_not_found** will raise an exception
+and deleting will be break. (by default **raise_if_not_found**=True)
+
+.. code-block:: python
+
+    >> selvpc.projects.delete_many(project_ids=["58e86b871f474fe2bb2874f9df1a0938",
+                                                "58e86b871f474fe2bb2874f9df1a0939",
+                                                "58e86b871f474fe2bb2874f9df1a0910"],
+                                                raise_if_not_found=False)
+
+      Project 58e86b871f474fe2bb2874f9df1a0938 was deleted
+      Project 58e86b871f474fe2bb2874f9df1a0939 was deleted
+      Project not found 58e86b871f474fe2bb2874f9df1a0910
+
 All available managers
 ----------------------
 

--- a/selvpcclient/commands/floatingips.py
+++ b/selvpcclient/commands/floatingips.py
@@ -73,7 +73,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<floating_ip_id>"
+            metavar="<floating_ip_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -85,8 +86,12 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].floatingips.delete(parsed_args.id)
-        self.logger.info("IP {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].floatingips.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False)
+        else:
+            self.app.context["client"].floatingips.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/floatingips.py
+++ b/selvpcclient/commands/floatingips.py
@@ -83,15 +83,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].floatingips.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False)
-        else:
-            self.app.context["client"].floatingips.delete(parsed_args.id[0])
+        self.app.context["client"].floatingips.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/license.py
+++ b/selvpcclient/commands/license.py
@@ -76,7 +76,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<license_id>"
+            metavar="<license_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -88,8 +89,13 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].licenses.delete(parsed_args.id)
-        self.logger.info("License {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].licenses.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False
+            )
+        else:
+            self.app.context["client"].licenses.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/license.py
+++ b/selvpcclient/commands/license.py
@@ -86,16 +86,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].licenses.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False
-            )
-        else:
-            self.app.context["client"].licenses.delete(parsed_args.id[0])
+        self.app.context["client"].licenses.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/project.py
+++ b/selvpcclient/commands/project.py
@@ -142,7 +142,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<project_id>"
+            metavar="<project_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -154,8 +155,13 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].projects.delete(parsed_args.id)
-        self.logger.info("Project {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].projects.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False
+            )
+        else:
+            self.app.context["client"].projects.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/project.py
+++ b/selvpcclient/commands/project.py
@@ -152,16 +152,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].projects.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False
-            )
-        else:
-            self.app.context["client"].projects.delete(parsed_args.id[0])
+        self.app.context["client"].projects.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/subnet.py
+++ b/selvpcclient/commands/subnet.py
@@ -83,7 +83,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<subnet_id>"
+            metavar="<subnet_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -95,8 +96,13 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].subnets.delete(parsed_args.id)
-        self.logger.info("Subnet {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].subnets.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False
+            )
+        else:
+            self.app.context["client"].subnets.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/subnet.py
+++ b/selvpcclient/commands/subnet.py
@@ -93,16 +93,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].subnets.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False
-            )
-        else:
-            self.app.context["client"].subnets.delete(parsed_args.id[0])
+        self.app.context["client"].subnets.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/user.py
+++ b/selvpcclient/commands/user.py
@@ -79,16 +79,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].users.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False
-            )
-        else:
-            self.app.context["client"].users.delete(parsed_args.id[0])
+        self.app.context["client"].users.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/user.py
+++ b/selvpcclient/commands/user.py
@@ -69,7 +69,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<user_id>"
+            metavar="<user_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -81,8 +82,13 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].users.delete(parsed_args.id)
-        self.logger.info("User {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].users.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False
+            )
+        else:
+            self.app.context["client"].users.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/vrrp.py
+++ b/selvpcclient/commands/vrrp.py
@@ -97,16 +97,12 @@ class Delete(CLICommand):
         )
         return parser
 
-    @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        if len(parsed_args.id) > 1:
-            self.app.context["client"].vrrp.delete_many(
-                parsed_args.id,
-                raise_if_not_found=False
-            )
-        else:
-            self.app.context["client"].vrrp.delete(parsed_args.id[0])
+        self.app.context["client"].vrrp.delete_many(
+            parsed_args.id,
+            raise_if_not_found=False
+        )
 
 
 class List(ListCommand):

--- a/selvpcclient/commands/vrrp.py
+++ b/selvpcclient/commands/vrrp.py
@@ -87,7 +87,8 @@ class Delete(CLICommand):
         parser = super(CLICommand, self).get_parser(prog_name)
         parser.add_argument(
             'id',
-            metavar="<vrrp_id>"
+            metavar="<vrrp_id>",
+            nargs='+'
         )
         parser.add_argument(
             '--yes-i-really-want-to-delete',
@@ -99,8 +100,13 @@ class Delete(CLICommand):
     @handle_http_error
     @confirm_action("delete")
     def take_action(self, parsed_args):
-        self.app.context["client"].vrrp.delete(parsed_args.id)
-        self.logger.info("Vrrp subnet {} was deleted".format(parsed_args.id))
+        if len(parsed_args.id) > 1:
+            self.app.context["client"].vrrp.delete_many(
+                parsed_args.id,
+                raise_if_not_found=False
+            )
+        else:
+            self.app.context["client"].vrrp.delete(parsed_args.id[0])
 
 
 class List(ListCommand):

--- a/selvpcclient/resources/floatingips.py
+++ b/selvpcclient/resources/floatingips.py
@@ -1,5 +1,10 @@
+import logging
+
 from selvpcclient import base
 from selvpcclient.util import resource_filter
+from selvpcclient.exceptions.base import ClientException
+
+log = logging.getLogger(__name__)
 
 
 class FloatingIP(base.Resource):
@@ -67,3 +72,18 @@ class FloatingIPManager(base.Manager):
         :param string floatingip_id: Floating ip id.
         """
         self._delete('/floatingips/{}'.format(floatingip_id))
+
+    def delete_many(self, floatingip_ids, raise_if_not_found=True):
+        """Delete few floating ips from domain.
+
+        :param list floatingip_ids: Subnet ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+        for f_id in floatingip_ids:
+            try:
+                self.delete(f_id)
+                log.info("IP {} was deleted".format(f_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, f_id))

--- a/selvpcclient/resources/floatingips.py
+++ b/selvpcclient/resources/floatingips.py
@@ -79,11 +79,11 @@ class FloatingIPManager(base.Manager):
         :param list floatingip_ids: Subnet ids list
         :param bool raise_if_not_found: Raise exception if object won't found
         """
-        for f_id in floatingip_ids:
+        for floatingip_id in floatingip_ids:
             try:
-                self.delete(f_id)
-                log.info("IP {} was deleted".format(f_id))
+                self.delete(floatingip_id)
+                log.info("IP {} was deleted".format(floatingip_id))
             except ClientException as err:
                 if raise_if_not_found:
                     raise err
-                log.error("{} {}".format(err, f_id))
+                log.error("{} {}".format(err, floatingip_id))

--- a/selvpcclient/resources/licenses.py
+++ b/selvpcclient/resources/licenses.py
@@ -83,11 +83,11 @@ class LicenseManager(base.Manager):
         :param list license_ids: Subnet ids list
         :param bool raise_if_not_found: Raise exception if object won't found
         """
-        for lic_id in license_ids:
+        for license_id in license_ids:
             try:
-                self.delete(lic_id)
-                log.info("License {} was deleted".format(lic_id))
+                self.delete(license_id)
+                log.info("License {} was deleted".format(license_id))
             except ClientException as err:
                 if raise_if_not_found:
                     raise err
-                log.error("{} {}".format(err, lic_id))
+                log.error("{} {}".format(err, license_id))

--- a/selvpcclient/resources/licenses.py
+++ b/selvpcclient/resources/licenses.py
@@ -1,5 +1,10 @@
+import logging
+
 from selvpcclient import base
 from selvpcclient.util import resource_filter
+from selvpcclient.exceptions.base import ClientException
+
+log = logging.getLogger(__name__)
 
 
 class License(base.Resource):
@@ -71,3 +76,18 @@ class LicenseManager(base.Manager):
         :param string license_id: License id.
         """
         self._delete('/licenses/{}'.format(license_id))
+
+    def delete_many(self, license_ids, raise_if_not_found=True):
+        """Delete few licenses from domain.
+
+        :param list license_ids: Subnet ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+        for lic_id in license_ids:
+            try:
+                self.delete(lic_id)
+                log.info("License {} was deleted".format(lic_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, lic_id))

--- a/selvpcclient/resources/projects.py
+++ b/selvpcclient/resources/projects.py
@@ -302,11 +302,11 @@ class ProjectsManager(base.Manager):
         :param bool raise_if_not_found: Raise exception if object won't found
         """
 
-        for proj_id in project_ids:
+        for project_id in project_ids:
             try:
-                self.delete(proj_id)
-                log.info("Project {} was deleted".format(proj_id))
+                self.delete(project_id)
+                log.info("Project {} was deleted".format(project_id))
             except ClientException as err:
                 if raise_if_not_found:
                     raise err
-                log.error("{} {}".format(err, proj_id))
+                log.error("{} {}".format(err, project_id))

--- a/selvpcclient/resources/projects.py
+++ b/selvpcclient/resources/projects.py
@@ -1,4 +1,7 @@
+import logging
+
 from selvpcclient import base
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.floatingips import FloatingIPManager
 from selvpcclient.resources.licenses import LicenseManager
 from selvpcclient.resources.quotas import QuotasManager
@@ -6,6 +9,9 @@ from selvpcclient.resources.roles import RolesManager
 from selvpcclient.resources.subnets import SubnetManager
 from selvpcclient.resources.tokens import TokensManager
 from selvpcclient.util import process_theme_params
+
+
+log = logging.getLogger(__name__)
 
 
 class Project(base.Resource):
@@ -288,3 +294,19 @@ class ProjectsManager(base.Manager):
 
         :param string project_id: Project id."""
         self._delete('/projects/{}'.format(project_id))
+
+    def delete_many(self, project_ids, raise_if_not_found=True):
+        """Delete few projects from domain.
+
+        :param list project_ids: Project ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+
+        for proj_id in project_ids:
+            try:
+                self.delete(proj_id)
+                log.info("Project {} was deleted".format(proj_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, proj_id))

--- a/selvpcclient/resources/subnets.py
+++ b/selvpcclient/resources/subnets.py
@@ -77,11 +77,11 @@ class SubnetManager(base.Manager):
         :param bool raise_if_not_found: Raise exception if object won't found
         """
 
-        for sub_id in subnet_ids:
+        for subnet_id in subnet_ids:
             try:
-                self.delete(sub_id)
-                log.info("Subnet {} was deleted".format(sub_id))
+                self.delete(subnet_id)
+                log.info("Subnet {} was deleted".format(subnet_id))
             except ClientException as err:
                 if raise_if_not_found:
                     raise err
-                log.error("{} {}".format(err, sub_id))
+                log.error("{} {}".format(err, subnet_id))

--- a/selvpcclient/resources/subnets.py
+++ b/selvpcclient/resources/subnets.py
@@ -1,5 +1,10 @@
+import logging
+
 from selvpcclient import base
 from selvpcclient.util import resource_filter
+from selvpcclient.exceptions.base import ClientException
+
+log = logging.getLogger(__name__)
 
 
 class Subnet(base.Resource):
@@ -64,3 +69,19 @@ class SubnetManager(base.Manager):
     def delete(self, subnet_id):
         """Delete subnet from domain."""
         self._delete('/subnets/{}'.format(subnet_id))
+
+    def delete_many(self, subnet_ids, raise_if_not_found=True):
+        """Delete few subnets from domain.
+
+        :param list subnet_ids: Subnet ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+
+        for sub_id in subnet_ids:
+            try:
+                self.delete(sub_id)
+                log.info("Subnet {} was deleted".format(sub_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, sub_id))

--- a/selvpcclient/resources/users.py
+++ b/selvpcclient/resources/users.py
@@ -1,5 +1,10 @@
+import logging
+
 from selvpcclient import base
 from selvpcclient.resources.roles import RolesManager
+from selvpcclient.exceptions.base import ClientException
+
+log = logging.getLogger(__name__)
 
 
 class User(base.Resource):
@@ -155,3 +160,18 @@ class UsersManager(base.Manager):
         :rtype: None
         """
         self._delete('/users/{}'.format(user_id))
+
+    def delete_many(self, user_ids, raise_if_not_found=True):
+        """Delete few users from domain.
+
+        :param list user_ids: User ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+        for user_id in user_ids:
+            try:
+                self.delete(user_id)
+                log.info("User {} was deleted".format(user_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, user_id))

--- a/selvpcclient/resources/vrrp.py
+++ b/selvpcclient/resources/vrrp.py
@@ -1,5 +1,10 @@
+import logging
+
 from selvpcclient import base
 from selvpcclient.util import resource_filter
+from selvpcclient.exceptions.base import ClientException
+
+log = logging.getLogger(__name__)
 
 
 class VRRP(base.Resource):
@@ -68,3 +73,18 @@ class VRRPManager(base.Manager):
         :param string vrrp_id: VRRP id.
         """
         self._delete('/vrrp_subnets/{}'.format(vrrp_id))
+
+    def delete_many(self, vrrp_ids, raise_if_not_found=True):
+        """Delete few vrrp subnets from domain.
+
+        :param list vrrp_ids: VRRP subnet ids list
+        :param bool raise_if_not_found: Raise exception if object won't found
+        """
+        for vrrp_id in vrrp_ids:
+            try:
+                self.delete(vrrp_id)
+                log.info("VRRP subnet {} was deleted".format(vrrp_id))
+            except ClientException as err:
+                if raise_if_not_found:
+                    raise err
+                log.error("{} {}".format(err, vrrp_id))

--- a/tests/cli/test_floatingip.py
+++ b/tests/cli/test_floatingip.py
@@ -80,3 +80,16 @@ def test_floating_ips_particle_resp():
             "--quantity", "1"]
     output = run_cmd(args, client, json_output=True)
     assert output == answers.FLOATING_IPS_PARTIAL_RESULT
+
+
+def test_floating_ips_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["floatingip delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/cli/test_floatingip.py
+++ b/tests/cli/test_floatingip.py
@@ -89,7 +89,4 @@ def test_floating_ips_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_license.py
+++ b/tests/cli/test_license.py
@@ -97,3 +97,16 @@ def test_licenses_partial_resp():
             '--quantity', '1']
     output = run_cmd(args, client, json_output=True)
     assert output == answers.LICENSES_PARTIAL_RESULT
+
+
+def test_licenses_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["license delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/cli/test_license.py
+++ b/tests/cli/test_license.py
@@ -106,7 +106,4 @@ def test_licenses_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -117,3 +117,16 @@ def test_project_reset_cname():
     assert output["enabled"] is True
     assert output["custom_url"] == ""
     assert "url" in output
+
+
+def test_project_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["project delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -126,7 +126,4 @@ def test_project_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_subnet.py
+++ b/tests/cli/test_subnet.py
@@ -108,7 +108,4 @@ def test_subnets_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_subnet.py
+++ b/tests/cli/test_subnet.py
@@ -99,3 +99,16 @@ def test_subnets_partial_resp():
 
     output = run_cmd(args, client, json_output=True)
     assert len(output) == 1
+
+
+def test_subnets_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["subnet delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/cli/test_user.py
+++ b/tests/cli/test_user.py
@@ -70,7 +70,4 @@ def test_user_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_user.py
+++ b/tests/cli/test_user.py
@@ -61,3 +61,16 @@ def test_user_role_list():
     assert len(output) == users_count
     assert output[0]["project_id"] == '1_7354286c9ebf464d86efc16fb56d4fa3'
     assert output[1]["project_id"] == '1_7354286c9ebf464d86efc16fb56d4fa3'
+
+
+def test_user_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["user delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/cli/test_vrrp.py
+++ b/tests/cli/test_vrrp.py
@@ -67,7 +67,4 @@ def test_vrrp_multiple_delete():
             "15c578ea47a5466db2aeb57dc8443676",
             "1ec578ea47a5466db2aeb57dc8443672",
             "16c578ea47a5466db2aeb57dc8443676"]
-    try:
-        run_cmd(args, client)
-    except Exception as exp:
-        pytest.fail("Unexpected exception {}".format(exp))
+    run_cmd(args, client)

--- a/tests/cli/test_vrrp.py
+++ b/tests/cli/test_vrrp.py
@@ -58,3 +58,16 @@ def test_vrrp_list_with_filters():
             "--project", "xxxxx68796e34858befb8fa2a8b1e12a"]
     output = run_cmd(args, client, json_output=True)
     assert len(output) == 0
+
+
+def test_vrrp_multiple_delete():
+    client = make_client(return_value=None)
+    args = ["vrrp delete",
+            "--yes-i-really-want-to-delete",
+            "15c578ea47a5466db2aeb57dc8443676",
+            "1ec578ea47a5466db2aeb57dc8443672",
+            "16c578ea47a5466db2aeb57dc8443676"]
+    try:
+        run_cmd(args, client)
+    except Exception as exp:
+        pytest.fail("Unexpected exception {}".format(exp))

--- a/tests/rest/test_floatingips.py
+++ b/tests/rest/test_floatingips.py
@@ -1,5 +1,7 @@
 import responses
+import pytest
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.floatingips import FloatingIPManager
 from tests.rest import client
 from tests.util import answers, params
@@ -106,3 +108,16 @@ def test_fips_raw_list():
     ips = manager.list(return_raw=True)
 
     assert ips == answers.FLOATINGIP_LIST["floatingips"]
+
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/floatingips/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/floatingips/200',
+                  status=404)
+
+    manager = FloatingIPManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(floatingip_ids=[100, 200])

--- a/tests/rest/test_licenses.py
+++ b/tests/rest/test_licenses.py
@@ -1,5 +1,7 @@
+import pytest
 import responses
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.licenses import LicenseManager
 from tests.rest import client
 from tests.util import answers, params
@@ -103,3 +105,16 @@ def test_list():
     licenses = manager.list(return_raw=True)
 
     assert licenses == answers.LICENSES_LIST["licenses"]
+
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/licenses/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/licenses/200',
+                  status=404)
+
+    manager = LicenseManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(license_ids=[100, 200])

--- a/tests/rest/test_projects.py
+++ b/tests/rest/test_projects.py
@@ -1,5 +1,7 @@
+import pytest
 import responses
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.projects import ProjectsManager
 from tests.rest import client
 from tests.util import answers, params
@@ -210,3 +212,15 @@ def test_get_raw_project_list():
     assert len(project_list_raw) > 0
     assert project_list_raw == answers.PROJECTS_LIST["projects"]
 
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/projects/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/projects/200',
+                  status=404)
+
+    manager = ProjectsManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(project_ids=[100, 200])

--- a/tests/rest/test_subnets.py
+++ b/tests/rest/test_subnets.py
@@ -1,5 +1,7 @@
+import pytest
 import responses
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.subnets import SubnetManager
 from tests.rest import client
 from tests.util import answers, params
@@ -108,3 +110,16 @@ def test_list_raw():
 
     subnets = manager.list(return_raw=True)
     assert subnets == answers.SUBNET_LIST["subnets"]
+
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/subnets/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/subnets/200',
+                  status=404)
+
+    manager = SubnetManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(subnet_ids=[100, 200])

--- a/tests/rest/test_users.py
+++ b/tests/rest/test_users.py
@@ -1,5 +1,7 @@
+import pytest
 import responses
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.users import UsersManager
 from tests.rest import client
 from tests.util import answers
@@ -179,3 +181,16 @@ def test_list_raw():
     users = manager.list(return_raw=True)
 
     assert users == answers.USERS_LIST["users"]
+
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/users/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/users/200',
+                  status=404)
+
+    manager = UsersManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(user_ids=[100, 200])

--- a/tests/rest/test_vrrp.py
+++ b/tests/rest/test_vrrp.py
@@ -1,5 +1,7 @@
+import pytest
 import responses
 
+from selvpcclient.exceptions.base import ClientException
 from selvpcclient.resources.vrrp import VRRPManager
 from tests.rest import client
 from tests.util import answers, params
@@ -91,3 +93,16 @@ def test_list_raw():
 
     subnets = manager.list(return_raw=True)
     assert subnets == answers.VRRP_LIST["vrrp_subnets"]
+
+
+@responses.activate
+def test_delete_multiple_with_raise():
+    responses.add(responses.DELETE, 'http://api/v2/vrrp_subnets/100',
+                  status=204)
+    responses.add(responses.DELETE, 'http://api/v2/vrrp_subnets/200',
+                  status=404)
+
+    manager = VRRPManager(client)
+
+    with pytest.raises(ClientException):
+        manager.delete_many(vrrp_ids=[100, 200])


### PR DESCRIPTION
- Add ability to delete few objects for CLI and library
- Add tests
- Update docs

E.x:
```

 $ selvpc project delete --yes-i-really-want-to-delete <project_id_1> ... <project_id_n>
 $ selvpc user delete --yes-i-really-want-to-delete <user_id_1> ... <user_id_n>
 $ selvpc license delete --yes-i-really-want-to-delete <license_id_1> ... <license_id_n>
 $ selvpc floatingip delete --yes-i-really-want-to-delete <floatingip_id_2> ... <floatingip_id_n>
 $ selvpc subnet delete --yes-i-really-want-to-delete <subnet_id_1> ... <subnet_id_n>
 $ selvpc vrrp delete --yes-i-really-want-to-delete <vrrp_id_1> ... <vrrp_id_n>
```

Add "delete_many" method for "ProjectManager", "UserManager", "LicenseManager, "VRRPManager",
"FloatingIPManager" and "SubnetsManager"

E.x:

```
  >> client.floatinip.delete_many(floating_ids=["123", "124"])
    # if some of ips are not found, it will raise an exception
    # to prevent it, need to add "raise_if_not_found=False"
  >> client.floatinip.delete_many(floating_ids=["123", "124"],
                                  raise_if_not_found=False)
```